### PR TITLE
Enable Debian Packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/barrelmaker97/pistachio"
 keywords = ["ups", "nut", "prometheus", "exporter", "monitoring"]
 authors = ["Nolan Cooper <nolancooper97@gmail.com>"]
 
+[profile.release]
+strip = "symbols"
+
 [dependencies]
 clap = { version = "4.5.17", features = ["derive", "env"] }
 env_logger = "0.11.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ authors = ["Nolan Cooper <nolancooper97@gmail.com>"]
 [profile.release]
 strip = "symbols"
 
+[package.metadata.deb]
+maintainer-scripts = "debian/"
+systemd-units = { enable = false }
+revision = ""
+
 [dependencies]
 clap = { version = "4.5.17", features = ["derive", "env"] }
 env_logger = "0.11.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM rust:1.81-slim AS builder
-
 WORKDIR /app
 
+# Build dependencies with empty main()
 COPY ./Cargo.toml .
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release
 
+# Copy in src, touch file to set modified time, then build
 COPY ./src src
 RUN touch src/main.rs
 RUN cargo build --release
-RUN strip target/release/pistachio
 
+# Copy binary to release image
 FROM debian:12.7-slim
 WORKDIR /app
 COPY --from=builder /app/target/release/pistachio .

--- a/README.md
+++ b/README.md
@@ -92,6 +92,37 @@ services:
       - "9120:9120"
 ```
 
+## Debian Package
+
+Using [cargo-deb](https://github.com/kornelski/cargo-deb), a .deb package for Pistachio can be built.
+This package can be used to install and run Pistachio as a systemd service.
+To create, install, and start the service, use the following steps:
+
+1. Install cargo-deb:
+    ```bash
+    cargo install cargo-deb
+    ```
+
+2. Build the Debian package:
+    ```bash
+    cargo deb
+    ```
+
+3. Install the generated package:
+    ```bash
+    sudo dpkg -i target/debian/pistachio_*.deb
+    ```
+
+4. Enable the systemd service:
+    ```bash
+    sudo systemctl enable pistachio
+    ```
+
+The package can be uninstalled by running the following:
+```bash
+sudo dpkg -P pistachio
+```
+
 ## Getting Started
 
 1. Clone the repository:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,61 @@ export POLL_RATE=5
 pistachio
 ```
 
+## Building Locally
+
+1. Clone the repository:
+    ```bash
+    git clone https://github.com/barrelmaker97/pistachio.git
+    ```
+
+2. Navigate to the project directory:
+    ```bash
+    cd pistachio
+    ```
+
+3. Build the project using Cargo:
+    ```bash
+    cargo build --release
+    ```
+
+4. Run the exporter:
+    ```bash
+    ./target/release/pistachio
+    ```
+
+5. Configure Prometheus to scrape metrics from the exporter at `http://<your_host>:<BIND_PORT>/metrics`.
+
+## Debian Package
+
+Using [cargo-deb](https://github.com/kornelski/cargo-deb), a .deb package for Pistachio can be built.
+This package can be used to install and run Pistachio as a systemd service.
+To create, install, and start the service, use the following steps:
+
+1. Install cargo-deb:
+    ```bash
+    cargo install cargo-deb
+    ```
+
+2. Build the Debian package:
+    ```bash
+    cargo deb
+    ```
+
+3. Install the generated package:
+    ```bash
+    sudo dpkg -i target/debian/pistachio_*.deb
+    ```
+
+4. Enable the systemd service:
+    ```bash
+    sudo systemctl enable pistachio
+    ```
+
+The package can be uninstalled by running the following:
+```bash
+sudo dpkg -P pistachio
+```
+
 ## Docker Image
 
 A pre-built Docker image of Pistachio is available on the GitHub Container Registry.
@@ -91,61 +146,6 @@ services:
     ports:
       - "9120:9120"
 ```
-
-## Debian Package
-
-Using [cargo-deb](https://github.com/kornelski/cargo-deb), a .deb package for Pistachio can be built.
-This package can be used to install and run Pistachio as a systemd service.
-To create, install, and start the service, use the following steps:
-
-1. Install cargo-deb:
-    ```bash
-    cargo install cargo-deb
-    ```
-
-2. Build the Debian package:
-    ```bash
-    cargo deb
-    ```
-
-3. Install the generated package:
-    ```bash
-    sudo dpkg -i target/debian/pistachio_*.deb
-    ```
-
-4. Enable the systemd service:
-    ```bash
-    sudo systemctl enable pistachio
-    ```
-
-The package can be uninstalled by running the following:
-```bash
-sudo dpkg -P pistachio
-```
-
-## Getting Started
-
-1. Clone the repository:
-    ```bash
-    git clone https://github.com/barrelmaker97/pistachio.git
-    ```
-
-2. Navigate to the project directory:
-    ```bash
-    cd pistachio
-    ```
-
-3. Build the project using Cargo:
-    ```bash
-    cargo build --release
-    ```
-
-4. Run the exporter:
-    ```bash
-    ./target/release/pistachio
-    ```
-
-5. Configure Prometheus to scrape metrics from the exporter at `http://<your_host>:<BIND_PORT>/metrics`.
 
 # License
 

--- a/debian/pistachio.service
+++ b/debian/pistachio.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pistachio
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart=/usr/bin/pistachio
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This allows the installation of Pistachio as a systemd service. The release profile has been updated to strip symbols from the binary and the README has been rearranged.