### PR TITLE
Service improvements

### DIFF
--- a/debian/pistachio.service
+++ b/debian/pistachio.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Pistachio
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=simple

--- a/debian/pistachio.service
+++ b/debian/pistachio.service
@@ -5,8 +5,9 @@ After=network.target network-online.target
 
 [Service]
 Type=simple
-Restart=on-failure
 ExecStart=/usr/bin/pistachio
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Wait for network to be available before starting, since Pistachio functions as a client and a server. Also increase time between restarts to 1s from default of 100ms to prevent rapid failure.